### PR TITLE
replace spaces before `dh_auto_install` with a tab

### DIFF
--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -1460,7 +1460,7 @@ RULES_MAIN = """\
 
 RULES_OVERRIDE_INSTALL_TARGET = """
 override_dh_auto_install:
-    dh_auto_install
+	dh_auto_install
 %(scripts_cleanup)s
 """
 


### PR DESCRIPTION
The recent changes look great but they generate an invalid makefile. The 4 spaces before `dh_auto_install` in the rules file should be a single tab character.